### PR TITLE
Fix: ensure PDFs are treated as multi-page in load_file (fixes #30)

### DIFF
--- a/chandra/input.py
+++ b/chandra/input.py
@@ -69,8 +69,17 @@ def load_file(filepath: str, config: dict):
         page_range = parse_range_str(page_range)
 
     input_type = filetype.guess(filepath)
+    is_pdf = False
+
+    # Prefer header-based detection but fall back to file extension.
     if input_type and input_type.extension == "pdf":
+        is_pdf = True
+    elif filepath.lower().endswith(".pdf"):
+        is_pdf = True
+
+    if is_pdf:
         images = load_pdf_images(filepath, page_range)
     else:
+        # Non‑PDF inputs are treated as single images.
         images = [load_image(filepath)]
     return images

--- a/tests/test_input_loader.py
+++ b/tests/test_input_loader.py
@@ -1,0 +1,31 @@
+from chandra import input as input_mod
+
+
+def test_load_file_uses_pdf_loader_when_extension_pdf(monkeypatch):
+    """Ensure load_file routes .pdf paths to load_pdf_images even if filetype.guess fails.
+
+    This simulates a multi-page PDF where only the first page would be used
+    if we treated the file as a single image.
+    """
+
+    calls = {}
+
+    def fake_guess(_):
+        # Simulate failure to detect PDF from file header.
+        return None
+
+    def fake_load_pdf_images(path, page_range):  # pragma: no cover - behavior verified via result
+        calls["path"] = path
+        calls["page_range"] = page_range
+        # Pretend we decoded three pages
+        return ["page0", "page1", "page2"]
+
+    monkeypatch.setattr(input_mod.filetype, "guess", fake_guess)
+    monkeypatch.setattr(input_mod, "load_pdf_images", fake_load_pdf_images)
+
+    images = input_mod.load_file("dummy.pdf", {"page_range": "0-2"})
+
+    assert images == ["page0", "page1", "page2"]
+    assert calls["path"].endswith("dummy.pdf")
+    # Parsed page range should be passed through as a list of ints
+    assert calls["page_range"] == [0, 1, 2]


### PR DESCRIPTION
Summary
-------
This PR improves PDF handling so that multi-page PDFs are always routed through the PDF loader, which returns one image per page. Previously, if `filetype.guess` failed to recognize a PDF from its header, `load_file` would treat the file as a single image, so only the first page would ever be processed, even when the caller expected a batch of pages.

Changes
-------
- Update `load_file` in `chandra/input.py` to:
  - Prefer header-based detection via `filetype.guess`.
  - Fall back to the `.pdf` file extension when `filetype.guess` returns `None`.
  - Always call `load_pdf_images` for PDFs, ensuring multi-page behavior.
- Add `tests/test_input_loader.py` to:
  - Mock `filetype.guess` to return `None`.
  - Mock `load_pdf_images` to simulate a 3-page PDF.
  - Assert that `load_file("dummy.pdf", {"page_range": "0-2"})` returns three “pages” and that the parsed page range `[0, 1, 2]` is passed through.

Relation to issue #30
---------------------
Issue #30 reports that only the first image is processed when using batch inputs from a PDF. When `load_file` misclassifies a PDF as a single image (because `filetype.guess` fails), the caller only ever gets one image and therefore only one `BatchInputItem` and result. This change makes PDF detection more robust and aligns `load_file` behavior with the expectation that a `.pdf` path yields multiple images (one per page), even if header detection fails.

Fixes #30