### PR TITLE
Security: Server-side XSS sink in Streamlit app (`unsafe_allow_html=True`) with model-controlled content

### DIFF
--- a/chandra/scripts/app.py
+++ b/chandra/scripts/app.py
@@ -130,7 +130,7 @@ if run_ocr:
                 ["HTML", "HTML as text", "Layout Image"]
             )
             with html_tab:
-                st.markdown(markdown_with_images, unsafe_allow_html=True)
+                st.markdown(markdown_with_images)
                 st.download_button(
                     label="Download Markdown",
                     data=result.markdown,


### PR DESCRIPTION
## Problem

The Streamlit UI renders OCR/model output using `st.markdown(..., unsafe_allow_html=True)`. Model output is not sanitized and may contain arbitrary HTML/JS-like payloads if prompted or induced by crafted input documents. This can execute script in users' browsers when viewing OCR results.

**Severity**: `high`
**File**: `chandra/scripts/app.py`

## Solution

Avoid `unsafe_allow_html=True` for untrusted content. If HTML rendering is required, sanitize output first using a strict allowlist sanitizer (e.g., Bleach) that removes scripts, event handlers, dangerous URLs (`javascript:`), and unsafe attributes/styles.

## Changes

- `chandra/scripts/app.py` (modified)

## Testing

- [ ] Existing tests pass
- [ ] Manual review completed
- [ ] No new warnings/errors introduced
