### PR TITLE
The aspect ratio of A4 paper is different from standard specifications. #95

### DIFF
--- a/chandra/model/util.py
+++ b/chandra/model/util.py
@@ -30,8 +30,11 @@ def scale_to_fit(
         scale = (min_pixels / current_pixels) ** 0.5
 
     # 2. Convert dimensions to integer "grid blocks"
+    # Derive h_blocks from rounded w_blocks to preserve aspect ratio.
+    # Independent rounding of both axes can push them in opposite directions
+    # (e.g. w rounds up, h rounds down), distorting the ratio.
     w_blocks = max(1, round((width * scale) / grid_size))
-    h_blocks = max(1, round((height * scale) / grid_size))
+    h_blocks = max(1, round(w_blocks * (height / width)))
 
     # 3. Refinement Loop: Ensure we are under the max limit
     while (w_blocks * h_blocks * grid_size * grid_size) > max_pixels:


### PR DESCRIPTION
## Summary

  When converting an A4 PDF, the rendered image has an aspect ratio of ~1.403
  instead of the expected 1.4142, due to grid quantization in `scale_to_fit`.

  ## Root Cause

  **Step 1** — `input.py: load_pdf_images` renders A4 correctly at 192 DPI:
  - 595.28 × 841.89 pt → 1587 × 2245 px → ratio **1.4147** ✓

  **Step 2** — `model/util.py: scale_to_fit` snaps to multiples of `grid_size=28`:
  ```python
  w_blocks = round(1587 / 28) = round(56.68) = 57  →  new_width  = 1596
  h_blocks = round(2245 / 28) = round(80.18) = 80  →  new_height = 2240
  Width rounds up (+9 px), height rounds down (−5 px) — both errors push
  the aspect ratio in the same direction:

  2240 / 1596 = 1.4035 ✗

  Impact

  The distortion is ~0.8%, which is negligible for OCR text accuracy, but causes
  systematic error when mapping bounding box coordinates back to the original PDF
  coordinate space.

  Environment

  - chandra-ocr v0.2.0
  - IMAGE_DPI = 192, MIN_PDF_IMAGE_DIM = 1024, grid_size = 28
