### PR TITLE
add CLI parameters vllm-api-base vllm-api-key

### DIFF
--- a/chandra/model/__init__.py
+++ b/chandra/model/__init__.py
@@ -29,6 +29,7 @@ class InferenceManager:
             )
         bbox_scale = kwargs.pop("bbox_scale", settings.BBOX_SCALE)
         vllm_api_base = kwargs.pop("vllm_api_base", settings.VLLM_API_BASE)
+        vllm_api_key = kwargs.pop("vllm_api_key", settings.VLLM_API_KEY)
 
         if self.method == "vllm":
             results = generate_vllm(
@@ -36,6 +37,7 @@ class InferenceManager:
                 max_output_tokens=max_output_tokens,
                 bbox_scale=bbox_scale,
                 vllm_api_base=vllm_api_base,
+                vllm_api_key=vllm_api_key,
                 **kwargs,
             )
         else:

--- a/chandra/model/vllm.py
+++ b/chandra/model/vllm.py
@@ -4,6 +4,7 @@ import time
 from concurrent.futures import ThreadPoolExecutor
 from itertools import repeat
 from typing import List
+import logging
 
 from PIL import Image
 from openai import OpenAI
@@ -12,6 +13,9 @@ from chandra.model.schema import BatchInputItem, GenerationResult
 from chandra.model.util import scale_to_fit, detect_repeat_token
 from chandra.prompts import PROMPT_MAPPING
 from chandra.settings import settings
+
+
+logger = logging.getLogger(__name__)
 
 
 def image_to_base64(image: Image.Image) -> str:
@@ -30,11 +34,16 @@ def generate_vllm(
     max_failure_retries: int | None = None,
     bbox_scale: int = settings.BBOX_SCALE,
     vllm_api_base: str = settings.VLLM_API_BASE,
+    vllm_api_key: str = settings.VLLM_API_KEY,
     temperature: float = 0.0,
     top_p: float = 0.1,
 ) -> List[GenerationResult]:
+    if not vllm_api_base.endswith("/v1"):
+        # this can fail with
+        # Exception: Unexpected endpoint or method. (POST /chat/completions)
+        logger.warning(f"vllm_api_base does not end with '/v1': {vllm_api_base!r}")
     client = OpenAI(
-        api_key=settings.VLLM_API_KEY,
+        api_key=vllm_api_key,
         base_url=vllm_api_base,
         default_headers=custom_headers,
     )
@@ -78,6 +87,8 @@ def generate_vllm(
                 temperature=temperature,
                 top_p=top_p,
             )
+            if hasattr(completion, "error"):
+                raise Exception(completion.error)
             raw = completion.choices[0].message.content
             result = GenerationResult(
                 raw=raw,

--- a/chandra/scripts/cli.py
+++ b/chandra/scripts/cli.py
@@ -21,6 +21,7 @@ def get_supported_files(input_path: Path) -> List[Path]:
         ".webp",
         ".tiff",
         ".bmp",
+        ".avif",
     }
 
     if input_path.is_file():

--- a/chandra/scripts/cli.py
+++ b/chandra/scripts/cli.py
@@ -7,6 +7,7 @@ import click
 from chandra.input import load_file
 from chandra.model import InferenceManager
 from chandra.model.schema import BatchInputItem
+from chandra.settings import settings
 
 
 def get_supported_files(input_path: Path) -> List[Path]:
@@ -160,6 +161,18 @@ def save_merged_output(
     help="Maximum number of retries for vLLM inference.",
 )
 @click.option(
+    "--vllm-api-base",
+    type=str,
+    default=settings.VLLM_API_BASE,
+    help=f"default: {settings.VLLM_API_BASE!r}",
+)
+@click.option(
+    "--vllm-api-key",
+    type=str,
+    default=settings.VLLM_API_KEY,
+    help=f"default: {settings.VLLM_API_KEY!r}",
+)
+@click.option(
     "--include-images/--no-images",
     default=True,
     help="Include images in output.",
@@ -193,6 +206,8 @@ def main(
     max_output_tokens: int,
     max_workers: int,
     max_retries: int,
+    vllm_api_base: str,
+    vllm_api_key: str,
     include_images: bool,
     include_headers_footers: bool,
     save_html: bool,
@@ -273,6 +288,10 @@ def main(
                         generate_kwargs["max_workers"] = max_workers
                     if max_retries is not None:
                         generate_kwargs["max_retries"] = max_retries
+                    if vllm_api_base is not None:
+                        generate_kwargs["vllm_api_base"] = vllm_api_base
+                    if vllm_api_key is not None:
+                        generate_kwargs["vllm_api_key"] = vllm_api_key
 
                 results = model.generate(batch, **generate_kwargs)
                 all_results.extend(results)


### PR DESCRIPTION
make it work with [lm-studio](https://lmstudio.ai/)

i prefer lm-studio over chandra_vllm
because docker container is overkill

this should also work with other OpenAI-compatible backends

### usage

1. start lm-studio
2. load the chandra-ocr-2 model
3. enable local server: developer &rarr; start server
4. run chandra

```sh
chandra test.png test.png.chandra \
  --method vllm \
  --vllm-api-base http://127.0.0.1:1234/v1 \
  --vllm-api-key lm-studio
```

### error handling

a wrong vllm-api-base like `http://127.0.0.1:1234`
was giving the confusing error

```
raw = completion.choices[0].message.content
          ~~~~~~~~~~~~~~~~~~^^^
TypeError: 'NoneType' object is not subscriptable
```

so now this honors completion.error
and it shows a warning if vllm-api-base does not end with `/v1`

### AVIF image format

fix #98 
