### PR TITLE
Fix off-by-one error in `parse_range_str` page range handling

### DIFF
--- a/chandra/input.py
+++ b/chandra/input.py
@@ -56,9 +56,9 @@ def parse_range_str(range_str: str) -> List[int]:
     for i in range_lst:
         if "-" in i:
             start, end = i.split("-")
-            page_lst += list(range(int(start), int(end) + 1))
+            page_lst += list(range(int(start) - 1, int(end)))
         else:
-            page_lst.append(int(i))
+            page_lst.append(int(i) - 1)
     page_lst = sorted(list(set(page_lst)))  # Deduplicate page numbers and sort in order
     return page_lst
 


### PR DESCRIPTION
`parse_range_str` returns 1-based page numbers, but `load_pdf_images` iterates with a 0-based index. This causes `--page-range 1` to return page 2, `--page-range 2` to return page 3, etc.

Fix in `chandra/input.py`, `parse_range_str`.

**Steps to reproduce error:**
1. Take a PDF where page 1 and page 2 have distinct content
2. Run `chandra input.pdf ./output --page-range 1`
3. Output contains page 2's content instead of page 1's