### PR TITLE
Add .tif to supported input extensions

### DIFF
--- a/chandra/scripts/cli.py
+++ b/chandra/scripts/cli.py
@@ -19,6 +19,7 @@ def get_supported_files(input_path: Path) -> List[Path]:
         ".gif",
         ".webp",
         ".tiff",
+        ".tif",
         ".bmp",
     }
 


### PR DESCRIPTION
Fixes #111.

`get_supported_files` in `chandra/scripts/cli.py` whitelisted `.tiff` but not `.tif`. Since `.tif` is the more common spelling (especially on Windows), TIFF files were rejected with "Unsupported file type: .tif" even though the model reads them fine after renaming. This adds `.tif` to the `supported_extensions` set.