### PR TITLE
docs: quote pip extras install examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,11 +62,11 @@ chandra_vllm
 chandra input.pdf ./output
 
 # With HuggingFace (requires torch)
-pip install chandra-ocr[hf]
+pip install 'chandra-ocr[hf]'
 chandra input.pdf ./output --method hf
 
 # Interactive streamlit app
-pip install chandra-ocr[app]
+pip install 'chandra-ocr[app]'
 chandra_app
 ```
 
@@ -113,10 +113,10 @@ See full scores [below](#benchmark-table).
 pip install chandra-ocr
 
 # With HuggingFace backend (includes torch, transformers)
-pip install chandra-ocr[hf]
+pip install 'chandra-ocr[hf]'
 
 # With all extras
-pip install chandra-ocr[all]
+pip install 'chandra-ocr[all]'
 ```
 
 If you're using the HuggingFace method, we also recommend installing [flash attention](https://github.com/Dao-AILab/flash-attention) for better performance.


### PR DESCRIPTION
## Summary
- Quote `pip install` examples that include extras.

## Why
- Shells such as zsh can expand unquoted bracket expressions before `pip` receives them.

## Scope
- Files changed:
- `README.md`
- This does not change dependencies or runtime behavior.

## Testing
- `git diff --check`

## Maintainer Fit
- Small install-command correctness fix.
- Duplicate PR search terms checked: `quote pip extras`, `quote optional dependency`, `zsh pip install extras`, `pip extras install examples`